### PR TITLE
Fix lack of buffer length

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-  reader: require('./lib/reader')
+  reader: require('./lib/hls-reader')
 };

--- a/lib/segment-decrypt.js
+++ b/lib/segment-decrypt.js
@@ -128,7 +128,8 @@ exports.decrypt = function (stream, keyAttrs, options, next) {
 
     let decrypt;
     try {
-      decrypt = Crypto.createDecipheriv('aes-128-cbc', keyData, key.iv);
+      const padLength = 16 - Buffer.byteLength(key.iv);
+      decrypt = Crypto.createDecipheriv('aes-128-cbc', keyData, Buffer.concat([Buffer.alloc(padLength), key.iv]));
     } catch (ex) {
       return next(new Error('crypto setup failed: ' + (ex.stack || ex)));
     }


### PR DESCRIPTION
Originally, use hlsdump will cause an error, "Invalid IV length". So I try to padleft the origin IV value to length 16. And then it works!!
